### PR TITLE
Allow target-role to be an ARN

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 # Contributing
 
-Please for and send a pull request.
+Please fork and send a pull request.


### PR DESCRIPTION
target-role can now be a name or an arn. simple.

Remember to add hacktoberfest tag to teh repo before merging this!