### PR TITLE
Add flags for setting AWS_PROFILE in environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,21 @@ Token is valid until: 2017-07-06 08:46:10 +0000 UTC
 ...
 ```
 
+### Set profile in environment
+`swamp` allows setting a profile as `AWS_PROFILE` in the environment. In order to activate this, at least `-export-profile` must be set.
+This tells swamp to write the profile to the a file (default is `/tmp/current_swamp_profile`) which can then be sourced and used in your shell. If you want to specify the file the profile is written to, you must also set `export-file`.
+
+#### Example
+With `export-file`:
+```
+$ swamp -target-profile target -target-role admin -account [target-account-id] -mfa-device arn:aws:iam::[origin-account-id]:mfa/[userid] -export-profile && source /tmp/current_swamp_profile
+```
+
+When setting `export-file` yourself:
+```
+$ swamp -target-profile target -target-role admin -account [target-account-id] -mfa-device arn:aws:iam::[origin-account-id]:mfa/[userid] -export-profile -export-file [/path/to/file] && source [/path/to/file]
+```
+
 ## Install
 
 Fetch the latest binary from https://github.com/felixb/swamp/releases or run `make` to compile it yourself.


### PR DESCRIPTION
This PR introduces an option which (kind of) allows setting `AWS_PROFILE` in env. Since I cannot imagine a way of changing the env in the parental process, I've chosen a workaround for that:

* By default, swamp behaves as always
* Using the new flag `-export-profile`, the profile is written to a file – `/tmp/current_swamp_profile` by default. Its content is basically just an export statement.
* If needed, the file can be specified using the `-export-file` flag.

Once the profile is written the file, it could be used like this in order to set `AWS_PROFILE` in the env (cf. README as well):
```
$ swamp -target-profile target -target-role admin -account [target-account-id] -mfa-device arn:aws:iam::[origin-account-id]:mfa/[userid] -export-profile && source /tmp/current_swamp_profile
```
Why? I frequently run into the problem that I deploy resources using terraform (having set a profile in the provider) and use aws cli for doing other things – most likely in the same script. Normally, `AWS_PROFILE` is not even set or at least set to a different profile than the one I assumed using swamp. This leads to funny constellations where you think you work in one account but actually do things in two different accounts...