### PR TITLE
add option to obtain the mfa-device token itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * obey environment variable `AWS_SHARED_CREDENTIALS_FILE`
 * hide flags `-export-profile` and `-export-file` on windows
 * `-target-profile` defaults to `swamp`
+* add option to automatically obtain the mfa-device token
 
 ## swamp v0.6
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ Token is valid until: 2017-07-06 08:31:10 +0000 UTC
 Subsequent calls may skip that step as long as the session token is still valid.
 With these intermediate credentials `aws sts assume-role` is called as above.
 
+### Auto-Obtain MFA Token
+if using swamp if an mfa-enabled account you can use the `-mfa-exec` flag to tell swamp
+to try to obtain the token itself. You need to give an executable command which returns the 6-digit code.
+
+
 #### Example:
 
 ```

--- a/config.go
+++ b/config.go
@@ -76,7 +76,10 @@ func (config *SwampConfig) SetupFlags() {
 	flag.StringVar(&config.tokenSerialNumber, "mfa-device", config.tokenSerialNumber, "MFA device arn")
 	flag.BoolVar(&config.useInstanceProfile, "instance", config.useInstanceProfile, "Use instance profile")
 	flag.BoolVar(&config.renew, "renew", config.renew, "renew token every duration/2")
-	flag.StringVar(&config.mfaExec, "mfa-exec", config.mfaExec, "executable command for obtaining mfa-device token")
+	if runtime.GOOS == "linux" {
+		//linux specific commands
+		flag.StringVar(&config.mfaExec, "mfa-exec", config.mfaExec, "executable command for obtaining mfa-device token")
+	}
 	if runtime.GOOS == "linux" || runtime.GOOS == "darwin" {
 		// platform specific flags
 		flag.BoolVar(&config.exportProfile, "export-profile", config.exportProfile, "set AWS_PROFILE in environment")

--- a/config.go
+++ b/config.go
@@ -29,6 +29,7 @@ type SwampConfig struct {
 	renew                bool
 	exportProfile        bool
 	exportFile           string
+	mfaExec              string
 }
 
 func NewSwampConfig() *SwampConfig {
@@ -46,6 +47,7 @@ func NewSwampConfig() *SwampConfig {
 		renew:                false,
 		exportProfile:        false,
 		exportFile:           "/tmp/current_swamp_profile",
+		mfaExec:              "",
 	}
 }
 
@@ -74,6 +76,7 @@ func (config *SwampConfig) SetupFlags() {
 	flag.StringVar(&config.tokenSerialNumber, "mfa-device", config.tokenSerialNumber, "MFA device arn")
 	flag.BoolVar(&config.useInstanceProfile, "instance", config.useInstanceProfile, "Use instance profile")
 	flag.BoolVar(&config.renew, "renew", config.renew, "renew token every duration/2")
+	flag.StringVar(&config.mfaExec, "mfa-exec", config.mfaExec, "executable command for obtaining mfa-device token")
 	if runtime.GOOS == "linux" || runtime.GOOS == "darwin" {
 		// platform specific flags
 		flag.BoolVar(&config.exportProfile, "export-profile", config.exportProfile, "set AWS_PROFILE in environment")
@@ -121,6 +124,12 @@ func (config *SwampConfig) Validate() error {
 
 	if config.tokenSerialNumber != "" {
 		if err := checkStringFlagNotEmpty("intermediate-profile", config.intermediateProfile); err != nil {
+			return err
+		}
+	}
+
+	if config.mfaExec != "" {
+		if err := checkStringFlagNotEmpty("mfa-device", config.tokenSerialNumber); err != nil {
 			return err
 		}
 	}

--- a/config.go
+++ b/config.go
@@ -76,14 +76,11 @@ func (config *SwampConfig) SetupFlags() {
 	flag.StringVar(&config.tokenSerialNumber, "mfa-device", config.tokenSerialNumber, "MFA device arn")
 	flag.BoolVar(&config.useInstanceProfile, "instance", config.useInstanceProfile, "Use instance profile")
 	flag.BoolVar(&config.renew, "renew", config.renew, "renew token every duration/2")
-	if runtime.GOOS == "linux" {
-		//linux specific commands
-		flag.StringVar(&config.mfaExec, "mfa-exec", config.mfaExec, "executable command for obtaining mfa-device token")
-	}
 	if runtime.GOOS == "linux" || runtime.GOOS == "darwin" {
 		// platform specific flags
 		flag.BoolVar(&config.exportProfile, "export-profile", config.exportProfile, "set AWS_PROFILE in environment")
 		flag.StringVar(&config.exportFile, "export-file", config.exportFile, "File to write AWS_PROFILE to")
+		flag.StringVar(&config.mfaExec, "mfa-exec", config.mfaExec, "executable command for obtaining mfa-device token")
 	}
 	flag.Usage = flagUsage
 }

--- a/config_test.go
+++ b/config_test.go
@@ -30,6 +30,23 @@ func TestSwampConfig_ValidateRoleAndAccount(t *testing.T) {
 	assert.Error(t, c.Validate())
 }
 
+func TestSwampConfig_ValidateMFADeviceAndTokenCommand(t *testing.T) {
+	c := NewSwampConfig()
+	c.targetRole = "arn:aws:iam::1234567890:role/some-role"
+	c.tokenSerialNumber = "someSerialNumber"
+	c.mfaExec = "some command"
+
+	assert.NoError(t, c.Validate())
+}
+
+func TestSwampConfig_ValidateNoMFADeviceButTokenCommand(t *testing.T) {
+	c := NewSwampConfig()
+	c.targetRole = "arn:aws:iam::1234567890:role/some-role"
+	c.mfaExec = "some command"
+
+	assert.Error(t, c.Validate())
+}
+
 func TestSwampConfig_GetRoleArnWithArn(t *testing.T) {
 	c := NewSwampConfig()
 	c.targetRole = "arn:aws:iam::1234567890:role/some-role"

--- a/swamp.go
+++ b/swamp.go
@@ -4,14 +4,13 @@ import (
 	"bufio"
 	"flag"
 	"fmt"
-	"os"
-	"strings"
-	"time"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sts"
+	"os"
 	"os/exec"
+	"strings"
+	"time"
 )
 
 func die(msg string, err error) {
@@ -34,11 +33,11 @@ func fetchTokenCode(tokenSerialNumber string, cmd string) *string {
 	}
 
 	fmt.Printf("Obtaining mfa token for: %s \n", tokenSerialNumber)
-	if output, err := exec.Command("bash", "-c", cmd).Output(); err != nil {
+	if output, err := exec.Command("sh", "-c", cmd).Output(); err != nil {
 		die("Error obtaining mfa token", err)
 		return nil
 	} else {
-		tokenCode := string(output)
+		tokenCode := strings.Trim(string(output[0:6]), " \r\n")
 		return &tokenCode
 	}
 }

--- a/swamp_test.go
+++ b/swamp_test.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSwamp_ExecutingMFACommand(t *testing.T) {
+	tokenCode := fetchTokenCode("someDeviceId", "echo 123456")
+
+	assert.EqualValues(t, "123456", tokenCode)
+}
+
+func TestSwamp_ExecutingMFACommandTrimNewLine(t *testing.T) {
+	tokenCode := fetchTokenCode("someDeviceId", "echo 123456\n")
+
+	assert.EqualValues(t, "123456", tokenCode)
+}
+
+func TestSwamp_ExecutingMFACommandTrimTooLongInput(t *testing.T) {
+	tokenCode := fetchTokenCode("someDeviceId", "echo 1234567")
+
+	assert.EqualValues(t, "123456", tokenCode)
+}


### PR DESCRIPTION
you can now use the "mfa-exec" flag to tell swamp to try to obtain the mfa-device token by itself.
therefore it will run the given command and expect the 6-digit code as the output.

Requirements from last pull request:
- [x]     remove the dependency to ykman and replace it with something like -mfa-exec <cmd> to allow any kind of token provider
- [x]     do not print out the fetched token
- [x]     ~~hide this option when running on windows~~ acknowledge this option only on linux systems
- [x]     obey the current code style - provided by ~~idea~~/goland auto formatter **(fmt)**
