### PR TITLE
filepath.Split instead of path.Split to make this platform independent

### DIFF
--- a/profile_writer.go
+++ b/profile_writer.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"os/user"
-	"path"
 	"path/filepath"
 	"time"
 
@@ -24,7 +23,7 @@ func NewProfileWriter() (*ProfileWriter, error) {
 	if credentialsPath, err := getCredentialsPath(); err != nil {
 		return nil, err
 	} else {
-		awsPath, _ := path.Split(credentialsPath)
+		awsPath, _ := filepath.Split(credentialsPath)
 		if awsPath == "" {
 			return nil, fmt.Errorf("Error generating path for credentials file")
 		}


### PR DESCRIPTION
Hi,
this is a late Christmas gift for your growing swamp fan base of Windows users.
path.Split cannot handle Windows paths (as stated in the docs: https://golang.org/pkg/path/#pkg-overview).
The filepath package however can handle this (https://golang.org/pkg/path/filepath/#pkg-overview).
Wonder how this ever worked for Windows users without specifying AWS_SHARED_CREDENTIALS_FILE env var with a Linux style path to the credentials file..

Cheers,
Christian